### PR TITLE
LBSD-2179 Introducing versions picker after selecting base theme

### DIFF
--- a/generators/app/templates/_package.json
+++ b/generators/app/templates/_package.json
@@ -8,6 +8,6 @@
   "author": "",
   "license": "AGPL-3.0",
   "dependencies": {
-    "liveblog-<%= base %>-theme": "latest"
+    "liveblog-<%= base %>-theme": "~<%= version %>"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,9 @@
   "dependencies": {
     "chalk": "^1.0.0",
     "mkdirp": "^0.5.1",
+    "request": "^2.85.0",
     "underscore.string": "^3.2.2",
-    "yeoman-generator": "1.1.1",
+    "yeoman-generator": "^2.0.5",
     "yosay": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
After the users pick the base theme we pull versions information from npmjs.org registry and show the latest 5 versions